### PR TITLE
Role-sets with exclusivity: only one role of each set

### DIFF
--- a/config.json
+++ b/config.json
@@ -75,6 +75,7 @@
                 "pending" : [],
                 "auto-role": [],
                 "whitelist": [],
+                "exclusivities": [],
                 "blacklist" : [],
                 "admin" : []
             },
@@ -113,7 +114,17 @@
                     "assets mass it",
                     "mother composer",
                     "learning",
-                    "Spectator"
+                    "Spectator",
+                    "Superman",
+                    "Batman",
+                    "Aquaman"
+                ],
+                "exclusivities": [
+                    [
+                        "Superman",
+                        "Batman",
+                        "Aquaman"
+                    ]
                 ],
                 "blacklist" : [],
                 "admin" : [
@@ -148,6 +159,7 @@
             "roles": {
                 "pending": [],
                 "whitelist": [],
+                "exclusivities": [],
                 "blacklist": [],
                 "admin" : []
             },
@@ -179,6 +191,7 @@
             "roles": {
                 "pending": [],
                 "whitelist": [],
+                "exclusivities": [],
                 "blacklist": [],
                 "admin" : []
             },

--- a/discord-util.js
+++ b/discord-util.js
@@ -205,7 +205,7 @@ function findModServer(client, serverJson, console) {
                     }
                     for (let exRole_innerCheck of roleSet) {
                         var roleToAddID = exports.discObjFind(server.roles, exRole_innerCheck).id;
-                        if (roleToAddID != exRoleID) {
+                        if (roleToAddID !== exRoleID) {
                             retval.exclusiveSets[exRoleID].add(roleToAddID);
                         }
                     }

--- a/discord-util.js
+++ b/discord-util.js
@@ -150,7 +150,7 @@ exports.discObjFind = function(obj, name) {
     return null;
 }
 function findModServer(client, serverJson, console) {
-    let retval = {id: "", chans: {}, pending: [], "auto-role": [], exclusiveSets: []};
+    let retval = {id: "", chans: {}, pending: [], "auto-role": [], exclusiveSets: {}};
     try {
         if (serverJson.name == "dm") {
             console.log("ERROR: \"dm\" is a reserved keyword for server names. Please use another regex instead.")
@@ -198,12 +198,18 @@ function findModServer(client, serverJson, console) {
 
         if (serverJson.roles.exclusivities) {
             for (let roleSet of serverJson.roles.exclusivities) {
-                var set = [];
                 for (let exRole of roleSet) {
-                    console.log(exRole);
-                    set.push(exports.discObjFind(server.roles, exRole).id);
+                    var exRoleID = exports.discObjFind(server.roles, exRole).id;
+                    if (!retval.exclusiveSets.hasOwnProperty(exRoleID)) {
+                        retval.exclusiveSets[exRoleID] = new Set();
+                    }
+                    for (let exRole_innerCheck of roleSet) {
+                        var roleToAddID = exports.discObjFind(server.roles, exRole_innerCheck).id;
+                        if (roleToAddID != exRoleID) {
+                            retval.exclusiveSets[exRoleID].add(roleToAddID);
+                        }
+                    }
                 }
-                retval.exclusiveSets.push(set);
             }
         }
 

--- a/discord-util.js
+++ b/discord-util.js
@@ -150,7 +150,7 @@ exports.discObjFind = function(obj, name) {
     return null;
 }
 function findModServer(client, serverJson, console) {
-    let retval = {id: "", chans: {}, pending: [],"auto-role" :[]};
+    let retval = {id: "", chans: {}, pending: [], "auto-role": [], exclusiveSets: []};
     try {
         if (serverJson.name == "dm") {
             console.log("ERROR: \"dm\" is a reserved keyword for server names. Please use another regex instead.")
@@ -193,6 +193,17 @@ function findModServer(client, serverJson, console) {
         if (serverJson.roles.admin) {
             for(let role of serverJson.roles.admin) {
                 roleAdmin.push(exports.discObjFind(server.roles, role).id);
+            }
+        }
+
+        if (serverJson.roles.exclusivities) {
+            for (let roleSet of serverJson.roles.exclusivities) {
+                var set = [];
+                for (let exRole of roleSet) {
+                    console.log(exRole);
+                    set.push(exports.discObjFind(server.roles, exRole).id);
+                }
+                retval.exclusiveSets.push(set);
             }
         }
 

--- a/modules/roles.js
+++ b/modules/roles.js
@@ -56,6 +56,9 @@ module.exports = function(client, util, config, console) {
             var guild = msg.guild;
             var member = msg.member;
 
+            console.log("User " + msg.author.id +
+                " executed add role with arguments: [" + args + "]");
+
             // users were mentioned
             if (msg.mentions.members.size) {
                 if (!util.isFromAdmin(msg)) {
@@ -126,6 +129,9 @@ module.exports = function(client, util, config, console) {
         },
         rm: function takeRoles(msg, args) {
             var member = msg.member;
+
+            console.log("User " + msg.author.id +
+                " executed rm role with arguments: [" + args + "]");
 
             // users were mentioned
             if (msg.mentions.members.size) {

--- a/modules/roles.js
+++ b/modules/roles.js
@@ -1,32 +1,35 @@
 module.exports = function(client, util, config, console) {
     function fetchRoles(obj, args) {
-        let roles = [], role;
+        let roles = [],
+            role;
         let bl = util.getRoleBlacklist();
         let wl = util.getRoleWhitelist();
         for (let arg of args) {
-//          console.log(util.discObjFind(obj, arg), " ", arg);
-            if ((role = util.discObjFind(obj, arg))
-              && wl.indexOf(role.id) !== -1 // use whitelist
-//              && bl.indexOf(role.id) === -1 // use blacklist
+            //          console.log(util.discObjFind(obj, arg), " ", arg);
+            if ((role = util.discObjFind(obj, arg)) &&
+                wl.indexOf(role.id) !== -1 // use whitelist
+                //              && bl.indexOf(role.id) === -1 // use blacklist
             )
-              roles.push(role);
+                roles.push(role);
         }
         return roles;
     }
+
     function fetchRole(roles, roleName) {
-      return util.discObjFind(roles, roleName);
+        return util.discObjFind(roles, roleName);
     }
+
     function getRolesName(roles) {
-      return roles.map(function(element) {
-           if(element.name.indexOf("@") == 0)
-                 return element.name.substring(1);
-           return element.name;
+        return roles.map(function(element) {
+            if (element.name.indexOf("@") == 0)
+                return element.name.substring(1);
+            return element.name;
         });
     }
     async function removeOtherRolesFromSet(user, rolesToAdd, roleMatched, set) {
         let ret = [];
         for (var i = 0; i < set.length; i++) {
-            if(set[i] != roleMatched.id) {
+            if (set[i] != roleMatched.id) {
                 for (var j = 0; j < rolesToAdd.length; j++) {
                     if (set[i] == rolesToAdd[j].id) {
                         rolesToAdd.splice(j, 1);
@@ -48,45 +51,45 @@ module.exports = function(client, util, config, console) {
         });
     }
     let commands = {
-		countMembers : function countAmount(msg, args) {
-			var guild = msg.guild;
-			var autoRoles = util.getRoles('auto-role', guild);
-			var members = guild.members.filter(function(member) {
-				return member.roles.has(autoRoles[0].id);
-			});
-			msg.channel.send(`There are ${members.size} members.`);
-		},
+        countMembers: function countAmount(msg, args) {
+            var guild = msg.guild;
+            var autoRoles = util.getRoles('auto-role', guild);
+            var members = guild.members.filter(function(member) {
+                return member.roles.has(autoRoles[0].id);
+            });
+            msg.channel.send(`There are ${members.size} members.`);
+        },
         add: async function giveRoles(msg, args) {
-			var guild = msg.guild;
-			var member = msg.member;
+            var guild = msg.guild;
+            var member = msg.member;
 
-			// users were mentioned
-			if(msg.mentions.members.size) {
-				if(!util.isFromAdmin(msg)) {
-					msg.reply('You are not an admin');
-					return;
-				}
-				member = msg.mentions.members.first();
-			}
+            // users were mentioned
+            if (msg.mentions.members.size) {
+                if (!util.isFromAdmin(msg)) {
+                    msg.reply('You are not an admin');
+                    return;
+                }
+                member = msg.mentions.members.first();
+            }
             let roles = fetchRoles(msg.guild.roles, args.join(" ").split(","));
             let dupRoles = [];
             //removes roles the user already has
-            for(var role of member.roles.array()) {
-              var index = -1;
-              if((index = roles.indexOf(role)) > -1) {
-                dupRoles = dupRoles.concat(roles.splice(index, 1));
-              }
+            for (var role of member.roles.array()) {
+                var index = -1;
+                if ((index = roles.indexOf(role)) > -1) {
+                    dupRoles = dupRoles.concat(roles.splice(index, 1));
+                }
             }
 
-            if(roles.length === 0) {
-              msg.channel.send(`Could not add any new roles.`);
-              return;
+            if (roles.length === 0) {
+                msg.channel.send(`Could not add any new roles.`);
+                return;
             }
-            if(!util.hasRoles('auto-role', guild, member, console)) {
-              var autoRoles = util.getRoles('auto-role', guild);
-			  for(let role of autoRoles) {
-				  roles.push(role);
-			  }
+            if (!util.hasRoles('auto-role', guild, member, console)) {
+                var autoRoles = util.getRoles('auto-role', guild);
+                for (let role of autoRoles) {
+                    roles.push(role);
+                }
             }
             console.log("algo start");
 
@@ -106,48 +109,48 @@ module.exports = function(client, util, config, console) {
             console.log("algo end");
 
             member.addRoles(roles).then(function(member) {
-                if(roles.length) {
-                  var newRolesName = getRolesName(roles).listjoin('and');
-                  util.log(msg, `Added ${newRolesName} to ${member}`);
-                  var dupRolesName = getRolesName(dupRoles).listjoin('and');
-                  var retMessage = `${member} is now ${newRolesName}.`;
-                  if(dupRoles.length) {
-                    retMessage += `\nAlready had ${dupRolesName}`;
-                  }
-                  msg.channel.send(retMessage);
+                if (roles.length) {
+                    var newRolesName = getRolesName(roles).listjoin('and');
+                    util.log(msg, `Added ${newRolesName} to ${member}`);
+                    var dupRolesName = getRolesName(dupRoles).listjoin('and');
+                    var retMessage = `${member} is now ${newRolesName}.`;
+                    if (dupRoles.length) {
+                        retMessage += `\nAlready had ${dupRolesName}`;
+                    }
+                    msg.channel.send(retMessage);
                 }
 
             }).catch(function(e) {
-              msg.channel.send('There was an error adding a role.');
-              console.log(e);
+                msg.channel.send('There was an error adding a role.');
+                console.log(e);
             });
         },
         get: function getRoles(msg) {
-          msg.channel.send("```\n" + getRolesName(msg.guild.roles).join("\n") + "```");
+            msg.channel.send("```\n" + getRolesName(msg.guild.roles).join("\n") + "```");
         },
         update: function updateList(msg) {
-          if(util.isFromAdmin(msg)) {
-            console.log("Is an admin");
-            util.updateServers(client, console);
-            console.log("Updated servers");
-            msg.channel.send("Updated successfully").catch(console.error);
-          } else {
-            console.log("Is not an admin");
-          }
+            if (util.isFromAdmin(msg)) {
+                console.log("Is an admin");
+                util.updateServers(client, console);
+                console.log("Updated servers");
+                msg.channel.send("Updated successfully").catch(console.error);
+            } else {
+                console.log("Is not an admin");
+            }
         },
         rm: function takeRoles(msg, args) {
-			var member = msg.member;
+            var member = msg.member;
 
-			// users were mentioned
-			if(msg.mentions.members.size) {
-				if(!util.isFromAdmin(msg)) {
-					msg.reply('You are not an admin');
-					return;
-				}
-				member = msg.mentions.members.first();
-			}
+            // users were mentioned
+            if (msg.mentions.members.size) {
+                if (!util.isFromAdmin(msg)) {
+                    msg.reply('You are not an admin');
+                    return;
+                }
+                member = msg.mentions.members.first();
+            }
             let role = fetchRoles(msg.guild.roles, args.join(" ").split(","));
-            if(role) {
+            if (role) {
                 member.removeRoles(role).then(function(member) {
                     var oldRoles = getRolesName(role).listjoin('or');
                     msg.channel.send(`${member} is no longer ${oldRoles}`);

--- a/modules/roles.js
+++ b/modules/roles.js
@@ -26,19 +26,24 @@ module.exports = function(client, util, config, console) {
             return element.name;
         });
     }
-    async function removeOtherRolesFromSet(user, rolesToAdd, roleMatched, set) {
-        let rolesToRemoveFromUser = user.roles.array().filter((role) => {
-            return set.has(role.id);
-        }).map((v) => v.id);
 
-        for (var i = 0; i < rolesToAdd.length; i++) {
-            if (set.has(rolesToAdd[i].id)) {
-                rolesToAdd.splice(i, 1);
+    /**
+    * Removes roles not pertaining to set `set` from Discord user `user`
+    * and role array **reference** `rolesToAdd_Ref`
+    * @param {Discord::GuildMember} user - User to remove roles from
+    * @param {Discord::Role[]} rolesToAdd_Ref - Reference to role array to
+    *                                           remove roles from
+    * @param {Set} set - Set that defines which roles will be removed
+    */
+    async function removeOtherRolesFromSet(user, rolesToAdd_Ref, set) {
+        for (var i = 0; i < rolesToAdd_Ref.length; i++) {
+            if (set.has(rolesToAdd_Ref[i].id)) {
+                rolesToAdd_Ref.splice(i, 1);
             }
         }
 
         for (var role of user.roles.array()) {
-            if (rolesToRemoveFromUser.includes(role.id)) {
+            if (set.has(role.id)) {
                 await user.removeRole(role);
             }
         }
@@ -93,7 +98,7 @@ module.exports = function(client, util, config, console) {
             let exclusiveSets = util.getRoles('exclusiveSets', guild);
             for (role of roles) {
                 if (exclusiveSets[role.id]) {
-                    await removeOtherRolesFromSet(member, roles, role.id, exclusiveSets[role.id]);
+                    await removeOtherRolesFromSet(member, roles, exclusiveSets[role.id]);
                 }
             }
 

--- a/modules/roles.js
+++ b/modules/roles.js
@@ -39,6 +39,7 @@ module.exports = function(client, util, config, console) {
         for (var i = 0; i < rolesToAdd_Ref.length; i++) {
             if (set.has(rolesToAdd_Ref[i].id)) {
                 rolesToAdd_Ref.splice(i, 1);
+                i--;
             }
         }
 


### PR DESCRIPTION
# Change-list:
- Now role "exclusivity sets" can be configured per-server.
- If a role is assigned to an user by the bot, and the role is within an exclusivity set, any other roles within that set are automaticly removed from the user before applying that role. Example config:
```json
"exclusivities": [
    [
        "Superman",
        "Batman",
        "Aquaman"
    ]
],
```
Then:
```
User roles: None

> .cc -roles add Batman
User roles: Batman

> .cc -roles add Superman
User roles: Superman

> .cc -roles add Aquaman
User roles: Aquaman
```
- Current behavior on multi-role: will assign only the first one, or the second one if the first is already assigned.